### PR TITLE
Fix: Enable type hint discovery and remove incorrect script entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "semantic-scholar-api"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python client for the Semantic Scholar API"
 readme = "README.md"
 authors = [
@@ -13,8 +13,6 @@ dependencies = [
     "tenacity>=9.0.0",
 ]
 
-[project.scripts]
-semantic-scholar-api = "semantic_scholar:main"
 
 [project.urls]
 Homepage = "https://github.com/bguisard/semantic-scholar-api"


### PR DESCRIPTION
- Add py.typed to allow type checkers to find inline type hints (PEP 561).
- Remove [project.scripts] from pyproject.toml as no CLI is provided.